### PR TITLE
[FEAT] 질문페이지 데이터베이스 연동

### DIFF
--- a/src/components/QuestionPage/ChoiceButtons.jsx
+++ b/src/components/QuestionPage/ChoiceButtons.jsx
@@ -1,16 +1,8 @@
 import styled from "styled-components";
 import Button from "../common/Button";
 
-function ChoiceButtons({ choice, onSelect }) {
-  return (
-    <ChoiceButton
-      onClick={() => {
-        alert("선택지 클릭!");
-      }}
-    >
-      울창한 대나무 숲길: 바람이 대나무 사이를 스치며 편안한 소리를 냅니다.
-    </ChoiceButton>
-  );
+function ChoiceButtons({ choiceText, onSelect }) {
+  return <ChoiceButton onClick={onSelect}>{choiceText}</ChoiceButton>;
 }
 
 export default ChoiceButtons;

--- a/src/components/QuestionPage/QuestionContent.jsx
+++ b/src/components/QuestionPage/QuestionContent.jsx
@@ -1,12 +1,13 @@
 import styled from "styled-components";
 import colors from "../../styles/color";
-import { useLocation } from "react-router-dom";
 
-function QuestionContent() {
+function QuestionContent({ questionNumber, totalQuestions, questionText }) {
   return (
     <StyledQuestion>
-      <div> 1 / 5 </div>
-      <div>d</div>
+      <div>
+        {questionNumber} / {totalQuestions}
+      </div>
+      <div>{questionText}</div>
     </StyledQuestion>
   );
 }

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -14,12 +14,15 @@ export default Button;
 const StyledButton = styled.button`
   border: none;
   border-radius: 15px;
-  width: 95%;
-  padding: 10px;
+  width: 470px;
+  height: 80px;
+  padding: 15px 20px;
   font-family: "NanumMyeongjo", serif;
   background-color: ${colors.button};
   color: white;
-  margin: 5px auto;
+  margin: 5px -5px;
+  line-height: 1.3;
+  justify-content: center;
   font-weight: bold;
   cursor: pointer;
 `;

--- a/src/components/home/HomeButton.jsx
+++ b/src/components/home/HomeButton.jsx
@@ -1,49 +1,37 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../../supabase";
 import styled from "styled-components";
 import Button from "../common/Button";
 
 function HomeButton({ language, text }) {
-  const [questionsData, setQuestionsData] = useState([]);
-  const [answersData, setAnswersData] = useState([]);
   const navigate = useNavigate();
-  //navigate state를 사용하여 다음 페이지로 이동하고, state를 전달합니다.
+
   const fetchData = async () => {
     try {
-      const questionColumn =
-        language === "한국어"
-          ? "question_ko"
-          : language === "English"
-          ? "question_en"
-          : "question_jp";
-
-      const answerColumn =
-        language === "한국어"
-          ? "answer_ko"
-          : language === "English"
-          ? "answer_en"
-          : "answer_jp";
+      const questionColumn = `question_${language === "한국어" ? "ko" : language === "English" ? "en" : "jp"}`;
+      const answerColumn = `answer_${language === "한국어" ? "ko" : language === "English" ? "en" : "jp"}`;
 
       const { data: fetchedQuestions, error: questionError } = await supabase
         .from("questions")
-        .select(`id, ${questionColumn}`);
+        .select(`id, ${questionColumn}`)
+        .order("id");
 
       if (questionError) throw questionError;
 
       const { data: fetchedAnswers, error: answerError } = await supabase
         .from("answers")
-        .select(`id, question_id, ${answerColumn}`);
+        .select(`id, question_id, ${answerColumn}`)
+        .order("id");
 
       if (answerError) throw answerError;
 
-      setQuestionsData(fetchedQuestions);
-      setAnswersData(fetchedAnswers);
-      // console.log(fetchedQuestions);
-      // console.log(fetchedAnswers);
-
-      navigate(`/question/${questionId}`, {
-        state: { questions: fetchedQuestions, answers: fetchedAnswers },
+      navigate("/question/1", {
+        state: {
+          questions: fetchedQuestions,
+          answers: fetchedAnswers,
+          currentQuestionIndex: 0,
+          selectedAnswers: [],
+        },
       });
     } catch (error) {
       console.error("Error fetching data:", error.message);
@@ -56,7 +44,5 @@ function HomeButton({ language, text }) {
 export default HomeButton;
 
 const CustomButton = styled(Button)`
-  height: 80px;
   font-size: 28px;
-  width: 100%;
 `;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,12 +25,14 @@ function HomePage() {
 
   return (
     <Wrapper>
-      <Title>{texts[language].title}</Title>
-      <DropdownWrapper>
-        <Dropdown />
-      </DropdownWrapper>
-      <HomeImg src={home_img} />
-      <HomeButton language={language} text={texts[language].button} />
+      <ContentWrapper>
+        <Title>{texts[language].title}</Title>
+        <DropdownWrapper>
+          <Dropdown />
+        </DropdownWrapper>
+        <HomeImg src={home_img} />
+        <HomeButton language={language} text={texts[language].button} />
+      </ContentWrapper>
       <HomePattern src={home_pattern} />
     </Wrapper>
   );
@@ -42,7 +44,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
 `;
 
 const Title = styled.h1`
@@ -72,5 +73,9 @@ const HomeImg = styled.img`
 
 const HomePattern = styled.img`
   width: calc(100% + 40px);
-  margin: 30px -20px 0px -20px;
+  margin: 60px -20px -20px -20px;
+`;
+
+const ContentWrapper = styled.div`
+  margin-top: 10px;
 `;

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -7,18 +7,22 @@ import KeywordList from "../components/common/results/KeywordList";
 import KeywordDetail from "../components/common/results/KeywordDetail";
 import colors from "../styles/color";
 import { useLanguage } from "../hooks/useLanguage";
+import { useLocation } from "react-router-dom";
 
 const ResultPage = () => {
   const [resultData, setResultData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  // const { language } = useLanguage();
-  const language = "한국어"; // 전역상태변수 사용 불가로 인한 임시 상수 데이터
+  const { language } = useLanguage();
+  const location = useLocation();
+  const { selectedAnswers } = location.state || {};
 
   useEffect(() => {
     const fetchResultData = async () => {
       try {
-        const { data, error } = await supabase.from("results").select("*").eq("id", 1).single();
+        const resultId = 1; // 임시로 1로 설정, 실제로는 답변에 따라 계산되어야 함
+
+        const { data, error } = await supabase.from("results").select("*").eq("id", resultId).single();
         if (error) throw error;
         setResultData(data);
       } catch (error) {
@@ -29,7 +33,7 @@ const ResultPage = () => {
     };
 
     fetchResultData();
-  }, []);
+  }, [selectedAnswers]);
 
   if (loading) return <div>로딩 중...</div>;
   if (error) return <div>{error}</div>;
@@ -42,13 +46,12 @@ const ResultPage = () => {
     ? new URL(`../assets/Kami/${resultData.kami_image_name}.png`, import.meta.url).href
     : null;
 
-  const hashtags = resultData[`hashtag_${language === "한국어" ? "ko" : language === "English" ? "en" : "ja"}`]
-    ? resultData[`hashtag_${language === "한국어" ? "ko" : language === "English" ? "en" : "ja"}`].split(",")
-    : [];
-  const description = resultData[`description_${language === "한국어" ? "ko" : language === "English" ? "en" : "ja"}`];
+  const langSuffix = language === "한국어" ? "ko" : language === "English" ? "en" : "ja";
 
-  const resultName = resultData[`result_name_${language === "한국어" ? "ko" : language === "English" ? "en" : "ja"}`];
-  const kamiName = resultData[`kami_name_${language === "한국어" ? "ko" : language === "English" ? "en" : "ja"}`];
+  const hashtags = resultData[`hashtag_${langSuffix}`]?.split(",") || [];
+  const description = resultData[`description_${langSuffix}`];
+  const resultName = resultData[`result_name_${langSuffix}`];
+  const kamiName = resultData[`kami_name_${langSuffix}`];
 
   return (
     <ResultLayout>


### PR DESCRIPTION
## 🏮 이슈 링크

> #39 

  <br/>

## 🧧 작업 내용

- 질문페이지 데이터베이스 연동
- 질문페이지에서 답변을 선택하면 다음 질문으로 이동
- 질문이 모두 끝나면 결과 페이지로 이동
- 언어에 따른 질문과 답변, 결과 출력
  <br/>
